### PR TITLE
feat: :sparkles: Изменение логики отображение на индексной.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ class PostResource extends ModelResource
 В модальном окне отображается только имя пользователя, заблокировавшего доступ к ресурсу. Для отображения иной информации вы можете создать свой класс, который будет унаследован от `ResourceLockOwnerAction`, и зарегистрировать его в конфигурационном файле. Таким образом, вы сможете настроить отображение дополнительных сведений о заблокировавшем доступ пользователе в модальном окне.
 Например:
 ```php
+<?php
+
 namespace App\Actions;
-//...
+
 use ForestLynx\ResourceLock\Actions\ResourceLockOwnerAction;
 
 class CustomActions extends ResourceLockOwnerAction
@@ -91,18 +93,43 @@ class CustomActions extends ResourceLockOwnerAction
 По умолчанию, когда вы нажимаете кнопку «Назад» в модальном окне заблокированного ресурса, происходит переход на индексную страницу ресурса. Однако вы можете изменить URL страницы редиректа, переопределив метод `getReturnUrlResourceLock` в вашем ресурсе.
 
 ```php
-    public function getReturnUrlResourceLock(): string
+<?php
+//...
+class PostResource extends ModelResource
+{
+    //...
+    use WithResourceLock;
+    //...
+    protected function getReturnUrlResourceLock(): string
     {
         return 'https://...';
     }
+    //...
+}
 ```
 ##### Отображение информации о заблокированном ресурсе на индексной странице
 
 На индексной странице ресурса по умолчанию отображается информация о том, что доступ к ресурсу был заблокирован другим пользователем. Это отображается в виде специального значка:
 ![preview](./screenshots/indexInfo.png)
 
-Чтобы управлять этим поведением, можно изменить параметр `resource_lock_to_index_page` в файле конфигурации `config/resource-lock.php`.
-
+Чтобы скрыть эту информацию на индексной странице ресурса, можно в конфигурационном файле установить для параметра `resource_lock_to_index_page` значение `false`.
+В зависимости от ваших потребностей, вы можете настроить отображение информации о заблокированном ресурсе на индексной странице ресурса с помощью объявления метода в вашем ресурсе `isDisplayOnIndexPage()`. Этот метод должен возвращать логическое значение `true` или `false`.
+Например:
+```php
+<?php
+//...
+class PostResource extends ModelResource
+{
+    //...
+    use WithResourceLock;
+    //...
+    public function isDisplayOnIndexPage(): bool
+    {
+        return false;
+    }
+    //...
+}
+```
 > [!CAUTION]
 > Пока это работает только для ресурсов с отображением через `TableBuilder`.
 

--- a/config/resource-lock.php
+++ b/config/resource-lock.php
@@ -20,8 +20,4 @@ return [
     */
     'resource_lock_owner' => \ForestLynx\MoonShine\Actions\ResourceLockOwnerAction::class,
 
-    /**
-     * Displaying information about resource blocking on the index page
-     */
-    'resource_lock_to_index_page' => true,
 ];

--- a/doc/README-EN.md
+++ b/doc/README-EN.md
@@ -62,6 +62,8 @@ The modal window displays only the name of the user who blocked access to the re
 For example:
 
 ```php
+<?php
+
 namespace App\Actions;
 //...
 use ForestLynx\ResourceLock\Actions\ResourceLockOwnerAction;
@@ -88,10 +90,19 @@ Then add it to the configuration file:
 By default, when you click the Back button in the modal window of a blocked resource, you are redirected to the index page of the resource. However, you can change the URL of the redirect page by overriding the `getReturnUrlResourceLock` method in your resource.
 
 ```php
-    public function getReturnUrlResourceLock(): string
+<?php
+//...
+class PostResource extends ModelResource
+{
+    //...
+    use WithResourceLock;
+    //...
+    protected function getReturnUrlResourceLock(): string
     {
         return 'https://...';
     }
+    //...
+}
 ```
 ##### Displaying information about a blocked resource on an index page
 
@@ -99,8 +110,24 @@ By default, the index page of the resource displays information that access to t
 
 ![preview](../screenshots/indexInfo.png)
 
-To control this behavior, you can change the `resource_lock_to_index_page` parameter in the configuration file `config/resource-lock.php `.
-
+To hide this information on the index page of a resource, you can set the `resource_lock_to_index_page` parameter to `false` in the configuration file.
+Depending on your needs, you can configure the display of information about the blocked resource on the index page of the resource by declaring the method in your resource `isDisplayOnIndexPage()'. This method should return a boolean value of `true` or `false'.
+Example:
+```php
+<?php
+//...
+class PostResource extends ModelResource
+{
+    //...
+    use WithResourceLock;
+    //...
+    public function isDisplayOnIndexPage(): bool
+    {
+        return false;
+    }
+    //...
+}
+```
 > [!CAUTION]
 > So far, this only works for resources with display via 'TableBuilder'.
 

--- a/src/Traits/WithResourceLock.php
+++ b/src/Traits/WithResourceLock.php
@@ -24,7 +24,7 @@ trait WithResourceLock
     {
         if (
             $this->isNowOnIndex()
-            && config('resource-lock.resource_lock_to_index_page')
+            && $this->isDisplayOnIndexPage()
         ) {
             $this->handleIndexPage();
         }
@@ -102,38 +102,44 @@ trait WithResourceLock
 
     protected function getModal(): Modal
     {
-            return Modal::make(
-                title: static fn () => __('resource-lock::ui.title'),
-                components: PageComponents::make([
-                $this->getPreview(),
-                Flex::make([
-                    ActionButton::make(
-                        label: __('resource-lock::ui.back_btn'),
-                        url: $this->getReturnUrlResourceLock(),
-                    )->info()->icon('heroicons.outline.arrow-uturn-left')
-                ])->justifyAlign('start')->itemsAlign('start')
-                ])
-            )->name('resource-lock-modal');
+        return Modal::make(
+            title: static fn () => __('resource-lock::ui.title'),
+            components: PageComponents::make([
+            $this->getPreview(),
+            Flex::make([
+                ActionButton::make(
+                    label: __('resource-lock::ui.back_btn'),
+                    url: $this->getReturnUrlResourceLock(),
+                )->info()->icon('heroicons.outline.arrow-uturn-left')
+            ])->justifyAlign('start')->itemsAlign('start')
+            ])
+        )->name('resource-lock-modal');
     }
 
     protected function getPreview(): Preview
     {
-            $content = config('resource-lock.show_owner_modal')
-            ? "{$this->getResourceLockOwner()} " . __('resource-lock::ui.locked_notice_user')
-            : __('resource-lock::ui.locked_notice');
-            return Preview::make(
-                formatted: static fn(): string => $content
-            )->customAttributes(['class' => 'mb-4']);
-    }
-
-    public function getReturnUrlResourceLock(): string
-    {
-            return $this->indexPageUrl();
+        $content = config('resource-lock.show_owner_modal')
+        ? "{$this->getResourceLockOwner()} " . __('resource-lock::ui.locked_notice_user')
+        : __('resource-lock::ui.locked_notice');
+        return Preview::make(
+            formatted: static fn(): string => $content
+        )->customAttributes(['class' => 'mb-4']);
     }
 
     protected function afterUpdated(Model $item): Model
     {
-            $this->modelLock->unlock();
-            return parent::afterUpdated($item);
+        $this->modelLock->unlock();
+        return parent::afterUpdated($item);
+    }
+
+    protected function getReturnUrlResourceLock(): string
+    {
+        return $this->indexPageUrl();
+    }
+
+    protected function isDisplayOnIndexPage(): bool
+    {
+        $config = config('resource-lock.resource_lock_to_index_page') ?? null;
+        return isset($config) ? $config : true;
     }
 }


### PR DESCRIPTION
Добавлен метод `isDisplayOnIndexPage()` для того, чтобы определить, нужно ли отображать информацию на главной странице. Также были внесены изменения в документацию.

[Подробнее](https://github.com/forest-lynx/moonshine-resource-lock/tree/display-on-index?tab=readme-ov-file#отображение-информации-о-заблокированном-ресурсе-на-индексной-странице)